### PR TITLE
feat: add header to csv_options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 EXTENSION = pg_csv
-EXTVERSION = 0.3
+EXTVERSION = 0.4
 
 DATA = $(wildcard sql/*--*.sql)
 

--- a/README.md
+++ b/README.md
@@ -71,3 +71,19 @@ select csv_agg(x, csv_options(bom := true)) from projects x;
  5,Orphan,
 (1 row)
 ```
+
+### Header
+
+You can omit or include the CSV header.
+
+```psql
+select csv_agg(x, csv_options(header := false)) from projects x;
+      csv_agg
+-------------------
+ 1,Windows 7,1    +
+ 2,Windows 10,1   +
+ 3,IOS,2          +
+ 4,OSX,2          +
+ 5,Orphan,
+(1 row)
+```

--- a/sql/pg_csv--0.3--0.4.sql
+++ b/sql/pg_csv--0.3--0.4.sql
@@ -1,0 +1,9 @@
+alter type csv_options add attribute header bool;
+
+create or replace function csv_options(
+  delimiter "char" default NULL,
+  bom       bool default NULL,
+  header    bool default NULL
+) returns csv_options as $$
+  select row(delimiter, bom, header)::csv_options;
+$$ language sql;

--- a/sql/pg_csv.sql
+++ b/sql/pg_csv.sql
@@ -1,10 +1,15 @@
 create type csv_options as (
   delimiter "char"
 , bom       bool
+, header    bool
 );
 
-create or replace function csv_options(delimiter "char" default NULL, bom bool default NULL) returns csv_options as $$
-  select row(delimiter, bom)::csv_options;
+create or replace function csv_options(
+  delimiter "char" default NULL,
+  bom       bool default NULL,
+  header    bool default NULL
+) returns csv_options as $$
+  select row(delimiter, bom, header)::csv_options;
 $$ language sql;
 
 create function csv_agg_transfn(internal, anyelement)

--- a/test/expected/bom.out
+++ b/test/expected/bom.out
@@ -36,3 +36,7 @@ FROM   projects x;
 7;"has  CR";8
 8;"has 
  CRLF""";8
+\echo
+
+\pset format aligned
+\pset tuples_only off

--- a/test/expected/header.out
+++ b/test/expected/header.out
@@ -1,0 +1,78 @@
+-- header
+SELECT csv_agg(x, csv_options(header:=true)) AS body
+FROM   projects x;
+             body              
+-------------------------------
+ id,name,client_id            +
+ 1,Windows 7,1                +
+ 2,"has,comma",1              +
+ ,,                           +
+ 4,OSX,2                      +
+ ,"has""quote",               +
+ 5,"has,comma and ""quote""",7+
+ 6,"has                       +
+  LF",7                       +
+ 7,"has \r CR",8              +
+ 8,"has \r                    +
+  CRLF""",8
+(1 row)
+
+-- no header
+SELECT csv_agg(x, csv_options(header:=false)) AS body
+FROM   projects x;
+             body              
+-------------------------------
+ 1,Windows 7,1                +
+ 2,"has,comma",1              +
+ ,,                           +
+ 4,OSX,2                      +
+ ,"has""quote",               +
+ 5,"has,comma and ""quote""",7+
+ 6,"has                       +
+  LF",7                       +
+ 7,"has \r CR",8              +
+ 8,"has \r                    +
+  CRLF""",8
+(1 row)
+
+-- no header with delimiter
+SELECT csv_agg(x, csv_options(delimiter:='|', header:=false)) AS body
+FROM   projects x;
+             body              
+-------------------------------
+ 1|Windows 7|1                +
+ 2|has,comma|1                +
+ ||                           +
+ 4|OSX|2                      +
+ |"has""quote"|               +
+ 5|"has,comma and ""quote"""|7+
+ 6|"has                       +
+  LF"|7                       +
+ 7|"has \r CR"|8              +
+ 8|"has \r                    +
+  CRLF"""|8
+(1 row)
+
+-- see bom.sql for an explanation of these settings
+\pset format unaligned
+\pset tuples_only on
+\echo
+
+-- no header with delimiter and BOM
+SELECT csv_agg(x, csv_options(delimiter:='|', header:=false, bom := true)) AS body
+FROM   projects x;
+﻿1|Windows 7|1
+2|has,comma|1
+||
+4|OSX|2
+|"has""quote"|
+5|"has,comma and ""quote"""|7
+6|"has 
+ LF"|7
+7|"has  CR"|8
+8|"has 
+ CRLF"""|8
+\echo
+
+\pset format aligned
+\pset tuples_only off

--- a/test/sql/bom.sql
+++ b/test/sql/bom.sql
@@ -12,3 +12,7 @@ FROM   projects x;
 -- include BOM with custom delimiter
 SELECT csv_agg(x, csv_options(delimiter := ';', bom := true)) AS body
 FROM   projects x;
+\echo
+
+\pset format aligned
+\pset tuples_only off

--- a/test/sql/header.sql
+++ b/test/sql/header.sql
@@ -1,0 +1,24 @@
+-- header
+SELECT csv_agg(x, csv_options(header:=true)) AS body
+FROM   projects x;
+
+-- no header
+SELECT csv_agg(x, csv_options(header:=false)) AS body
+FROM   projects x;
+
+-- no header with delimiter
+SELECT csv_agg(x, csv_options(delimiter:='|', header:=false)) AS body
+FROM   projects x;
+
+-- see bom.sql for an explanation of these settings
+\pset format unaligned
+\pset tuples_only on
+\echo
+
+-- no header with delimiter and BOM
+SELECT csv_agg(x, csv_options(delimiter:='|', header:=false, bom := true)) AS body
+FROM   projects x;
+\echo
+
+\pset format aligned
+\pset tuples_only off


### PR DESCRIPTION
Adds the option to do:

```sql
select csv_agg(x, csv_options(header := false)) from projects x;
      csv_agg
-------------------
 1,Windows 7,1    +
 2,Windows 10,1   +
 3,IOS,2          +
 4,OSX,2          +
 5,Orphan,
(1 row)
```