### PR TITLE
fix: compile -Wunterminated-string-initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 EXTENSION = pg_csv
-EXTVERSION = 1.0
+EXTVERSION = 1.0.1
 
 DATA = $(wildcard sql/*--*.sql)
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,9 @@
 with import (builtins.fetchTarball {
-  name = "25.05";
-  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/25.05.tar.gz";
-  sha256 = "sha256:1915r28xc4znrh2vf4rrjnxldw2imysz819gzhk9qlrkqanmfsxd";
+  name = "2025-06-16";
+  url = "https://github.com/NixOS/nixpkgs/archive/e6f23dc08d3624daab7094b701aa3954923c6bbb.tar.gz";
+  sha256 = "sha256:0m0xmk8sjb5gv2pq7s8w7qxf7qggqsd3rxzv3xrqkhfimy2x7bnx";
 }) {};
-mkShell {
+mkShellNoCC {
   buildInputs =
     let
     xpg = import (fetchFromGitHub { owner  = "steve-chavez";
@@ -46,6 +46,7 @@ mkShell {
       style
       styleCheck
       loadtest
+      gcc15
     ];
   shellHook = ''
     export HISTFILE=.history

--- a/sql/pg_csv--1.0--1.0.1.sql
+++ b/sql/pg_csv--1.0--1.0.1.sql
@@ -1,0 +1,1 @@
+-- no SQL changes in 1.0.1

--- a/src/aggs.c
+++ b/src/aggs.c
@@ -7,7 +7,7 @@
 const char NEWLINE = '\n';
 const char DQUOTE  = '"';
 const char CR      = '\r';
-const char BOM[3]  = "\xEF\xBB\xBF";
+const char BOM[]   = {0xEF, 0xBB, 0xBF};
 
 static inline bool is_reserved(char c) {
   return c == DQUOTE || c == NEWLINE || c == CR;


### PR DESCRIPTION
Closes https://github.com/PostgREST/pg_csv/issues/10. This option is included by default on GCC 15 with -Wextra.

Not really a bug in the codebase as we don't use the null terminator, we use the exact size of the BOM string for appending it. See:

https://github.com/PostgREST/pg_csv/blob/d452df84261c34ab81788af3241fbd2753114a3f/src/pg_csv.c#L69

This now changes compilation to always use GCC 15.