### PR TITLE
add: csv_populate_recordset 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ $(BUILD_DIR)/.gitignore: sql/$(EXTENSION)--$(EXTVERSION).sql $(EXTENSION).contro
 $(BUILD_DIR)/%.o: $(SRC_DIR)/%.c $(BUILD_DIR)/.gitignore
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
+$(BUILD_DIR)/pg_csv.o: $(SRC_DIR)/csv.h $(SRC_DIR)/cparsec.h
+src/pg_csv.o: $(SRC_DIR)/csv.h $(SRC_DIR)/cparsec.h
+
 $(BUILD_DIR)/$(EXTENSION).$(SHARED_EXT): $(EXTENSION).$(SHARED_EXT)
 	mv $? $@
 

--- a/sql/pg_csv.sql
+++ b/sql/pg_csv.sql
@@ -29,6 +29,11 @@ create function csv_agg_finalfn(internal)
   language c
 as 'MODULE_PATHNAME';
 
+create function csv_populate_recordset(anyelement, text, has_header bool default false)
+  returns setof anyelement
+  language c
+as 'MODULE_PATHNAME';
+
 create aggregate csv_agg(anyelement) (
   sfunc     = csv_agg_transfn,
   stype     = internal,

--- a/src/cparsec.h
+++ b/src/cparsec.h
@@ -1,0 +1,548 @@
+#ifndef CPARSEC_H_INCLUDED
+#define CPARSEC_H_INCLUDED
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#if defined(CPC_USE_STRING_H)
+#  include <string.h>
+#endif
+
+// The basic element of the parser are string slices to enable zero-copy parsing
+typedef struct {
+  const char *ptr;
+  size_t      len;
+} CpcSlice;
+
+// The list is a range in the arena [start..len]
+typedef struct {
+  size_t start;
+  size_t len;
+} CpcList;
+
+// obtain a CpcSlice from a c string
+static inline CpcSlice cpc_slice_from_cstr(const char *s) {
+#if defined(CPC_USE_STRING_H)
+  return (CpcSlice){.ptr = s, .len = strlen(s)};
+// The non string.h implementation of this function is very basic and scans byte by byte instead of
+// word by word. We can optimize this as discussed on
+// https://github.com/steve-chavez/CParseC/issues/3, but for now we leave that to `strlen` for
+// environments that use string.h. glibc `strlen` has various optimizations including SIMD.
+#else
+  size_t n = 0;
+  while (s[n] != '\0')
+    n++;
+  return (CpcSlice){.ptr = s, .len = n};
+#endif
+}
+
+// a sub region of the slice
+static inline CpcSlice cpc_slice_sub(CpcSlice s, size_t start, size_t len) {
+  return (CpcSlice){.ptr = s.ptr + start, .len = len};
+}
+
+typedef enum { CPC_NOTHING, CPC_SLICE, CPC_LIST, CPC_PTR } CpcValueKind;
+typedef struct {
+  CpcValueKind kind;
+
+  union {
+    CpcSlice slice;
+    CpcList  list;
+    void    *ptr;
+  } as;
+} CpcValue;
+
+// Dedicated bump arena for CpcValues
+typedef struct {
+  CpcValue *items;  // storage items
+  size_t    cap;    // capacity
+  size_t    offset; // bump pointer offset [0..cap]
+  void     *user;   // user pointer data for use on the fmap, we don't handle its
+                    // lifecycle
+} CpcArena;
+
+// the signature is like this because both the arena and the items have to be
+// declared separately to allow static or stack allocation
+static inline void cpc_arena_init(CpcArena *a, CpcValue *items, size_t cap, void *user) {
+  *a = (CpcArena){.items = items, .cap = cap, .offset = 0, .user = user};
+}
+
+// reset the arena offset
+static inline void cpc_arena_reset(CpcArena *a) {
+  a->offset = 0;
+}
+
+typedef enum {
+  CPC_ERR_NONE,
+  CPC_ERR_PARSE,
+  CPC_ERR_ARENA_FULL,
+  CPC_ERR_NO_PROGRESS,
+} CpcErrKind;
+
+typedef struct {
+  CpcErrKind  kind;
+  const char *msg;
+} CpcErr;
+
+// returns the accepted output value and the rest of the string as another slice
+typedef struct {
+  bool     ok;
+  CpcValue out;
+  CpcSlice rest;
+  CpcErr   err;
+} CpcResult;
+
+static inline CpcResult cpc_res_ok(CpcValue out, CpcSlice rest) {
+  return (CpcResult){
+    .out = out, .rest = rest, .ok = true, .err = {.kind = CPC_ERR_NONE, .msg = NULL}};
+}
+
+// Allows to specify a default error message with an overriding label
+static inline CpcResult cpc_res_err(CpcSlice rest, const char *def, const char *label) {
+  return (CpcResult){.out  = (CpcValue){.kind = CPC_NOTHING},
+                     .rest = rest,
+                     .ok   = false,
+                     .err  = {.kind = CPC_ERR_PARSE, .msg = label ? label : def}};
+}
+
+static inline CpcResult cpc_res_internal_err(CpcSlice rest, CpcErrKind kind) {
+  return (CpcResult){.out  = (CpcValue){.kind = CPC_NOTHING},
+                     .rest = rest,
+                     .ok   = false,
+                     .err  = {.kind = kind, .msg = NULL}};
+}
+
+static inline CpcValue cpc_val_slice(CpcSlice s) {
+  return (CpcValue){.kind = CPC_SLICE, .as.slice = s};
+}
+
+static inline CpcValue cpc_val_list(CpcArena *A) {
+  return (CpcValue){.kind = CPC_LIST, .as.list = {.start = A->offset, .len = 0}};
+}
+
+static inline CpcValue cpc_val_nothing(void) {
+  return (CpcValue){.kind = CPC_NOTHING};
+}
+
+static inline CpcValue cpc_val_ptr(void *p) {
+  return (CpcValue){.kind = CPC_PTR, .as.ptr = p};
+}
+
+static inline bool cpc_is_list(const CpcValue *v) {
+  return v && v->kind == CPC_LIST;
+}
+
+static inline bool cpc_is_slice(const CpcValue *v) {
+  return v && v->kind == CPC_SLICE;
+}
+
+static inline bool cpc_is_nothing(const CpcValue *v) {
+  return v && v->kind == CPC_NOTHING;
+}
+
+static inline bool cpc_val_list_push(CpcArena *A, CpcValue *list, CpcValue x) {
+  // TODO differentiate between these errors
+  if (!A) return false;
+  if (!cpc_is_list(list)) return false;
+  if (A->offset >= A->cap) return false;
+
+  A->items[A->offset++] = x;
+  list->as.list.len++;
+
+  return true;
+}
+
+static inline const CpcValue *cpc_val_list_at(const CpcArena *A, const CpcValue *list, size_t i) {
+  if (!A || !cpc_is_list(list) || i >= list->as.list.len) return NULL;
+  return &A->items[list->as.list.start + i];
+}
+
+// If the current slice is the same as the previous slice, no progress was made.
+// This condition ensures all the parsers never cause infinite loops, which is a
+// problem in Haskell Parsec. See
+// https://hackage.haskell.org/package/attoparsec-0.14.4/docs/Data-Attoparsec-ByteString.html#v:takeWhile
+static inline bool cpc_no_progress_made(const CpcSlice cur, const CpcSlice prev) {
+  return (cur.ptr == prev.ptr && cur.len == prev.len);
+}
+
+// Note that GCC unused really means "may be unused", some parsers do use the
+// arena (and no error is thrown) and others don't use it.
+#define CPC_DEFINE_PARSER(name)                                                                    \
+  CpcResult name(CpcSlice input, __attribute__((unused)) CpcArena *A,                              \
+                 __attribute__((unused)) const char *err)
+
+// Wrapper for running the parser. This is to prevent breaking changes later if the parser
+// signature is changed.
+#define CPC_PARSE(parser, input, arena) (parser)((input), (arena), NULL)
+
+// This is guarded behind a macro because it requires nested functions
+#ifdef CPC_USE_UNNAMED
+#  define CPC_DEFINE_PARSER_(name, body) ({ CPC_DEFINE_PARSER(name) body name; })
+#endif
+
+// `##` does not expand `__COUNTER__` before token pasting, so an
+// extra macro is needed to build identifiers like `cpc_string_7`
+#define CPC_CONCAT_(x, y) x##y
+#define CPC_CONCAT(x, y) CPC_CONCAT_(x, y)
+
+// This is more like Parsec `string'`, which doesn't consume the matching
+// prefix. We do this to avoid having a `try` function and working better with
+// `alt`
+#define ___CPC_STRING_BODY(lit)                                                                    \
+  {                                                                                                \
+    const CpcSlice slice = {.ptr = (lit), .len = sizeof(lit) - 1};                                 \
+                                                                                                   \
+    if (input.len < slice.len) return cpc_res_err(input, "mismatch", err);                         \
+                                                                                                   \
+    for (size_t i = 0; i < slice.len; ++i)                                                         \
+      if (input.ptr[i] != slice.ptr[i]) return cpc_res_err(input, "mismatch", err);                \
+                                                                                                   \
+    return cpc_res_ok(cpc_val_slice(cpc_slice_sub(input, 0, slice.len)),                           \
+                      cpc_slice_sub(input, slice.len, input.len - slice.len));                     \
+  }
+
+#define CPC_STRING(name, lit) CPC_DEFINE_PARSER(name) ___CPC_STRING_BODY(lit)
+#ifdef CPC_USE_UNNAMED
+#  define CPC_STRING_(lit)                                                                         \
+    CPC_DEFINE_PARSER_(CPC_CONCAT(cpc_string_, __COUNTER__), ___CPC_STRING_BODY(lit))
+#endif
+
+#define ___CPC_ANY(name)                                                                           \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    if (input.len == 0) return cpc_res_err(input, "eof", err);                                     \
+    return cpc_res_ok(cpc_val_slice(cpc_slice_sub(input, 0, 1)),                                   \
+                      cpc_slice_sub(input, 1, input.len - 1));                                     \
+  }
+
+// Succeeds if there is at least one character of input. Returns the parsed character.
+#define CPC_ANY(name) ___CPC_ANY(name)
+static inline ___CPC_ANY(CPC_ANY_)
+
+// Succeeds if the character is in the supplied string. Returns the parsed character.
+#define CPC_ONE_OF(name, chars)                                                                    \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    if (input.len == 0) return cpc_res_err(input, "none matched", err);                            \
+    for (size_t i = 0; (chars)[i] != '\0'; i++)                                                    \
+      if (input.ptr[0] == (chars)[i])                                                              \
+        return cpc_res_ok(cpc_val_slice(cpc_slice_sub(input, 0, 1)),                               \
+                          cpc_slice_sub(input, 1, input.len - 1));                                 \
+    return cpc_res_err(input, "none matched", err);                                                \
+  }
+
+// `alt` for "alternative" is the equivalent of Parsec `<|>`
+#define CPC_ALT(name, x, y)                                                                        \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    CpcResult res = (x)(input, A, err);                                                            \
+    if (res.ok)                                                                                    \
+      return res;                                                                                  \
+    else                                                                                           \
+      return (y)(input, A, err);                                                                   \
+  }
+
+#define CPC_LABEL(name, parser, label)                                                             \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    return (parser)(input, A, err ? err : (label));                                                \
+  }
+
+// `right` is the equivalent of Haskell's Applicative right sequencing `*>`
+#define CPC_RIGHT(name, x, y)                                                                      \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    CpcResult res = (x)(input, A, err);                                                            \
+    if (!res.ok)                                                                                   \
+      return res;                                                                                  \
+    else                                                                                           \
+      return (y)(res.rest, A, err);                                                                \
+  }
+
+// `left` is the equivalent of Haskell's Applicative left sequencing `<*`
+#define CPC_LEFT(name, x, y)                                                                       \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    CpcResult res1 = (x)(input, A, err);                                                           \
+    if (!res1.ok) return res1;                                                                     \
+                                                                                                   \
+    CpcResult res2 = (y)(res1.rest, A, err);                                                       \
+    if (!res2.ok) return res2;                                                                     \
+                                                                                                   \
+    return cpc_res_ok(res1.out, res2.rest);                                                        \
+  }
+
+// `apply` is the equivalent of Haskell's Applicative sequential application
+// `<*> It produces a list of 2 elements, but this can be mapped to another
+// struct
+#define CPC_APPLY(name, x, y)                                                                      \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    CpcResult r1 = (x)(input, A, err);                                                             \
+    if (!r1.ok) return r1;                                                                         \
+    CpcResult r2 = (y)(r1.rest, A, err);                                                           \
+    if (!r2.ok) return r2;                                                                         \
+                                                                                                   \
+    CpcValue out = cpc_val_list(A);                                                                \
+                                                                                                   \
+    if (!cpc_val_list_push(A, &out, r1.out))                                                       \
+      return cpc_res_internal_err(r1.rest, CPC_ERR_ARENA_FULL);                                    \
+                                                                                                   \
+    if (!cpc_val_list_push(A, &out, r2.out))                                                       \
+      return cpc_res_internal_err(r2.rest, CPC_ERR_ARENA_FULL);                                    \
+                                                                                                   \
+    return cpc_res_ok(out, r2.rest);                                                               \
+  }
+
+// `map` is the equivalent of Haskell's `<$>`. Does not fail.
+#define CPC_MAP(name, x, fn)                                                                       \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    CpcResult r = x(input, A, err);                                                                \
+    return (fn)(A, &r.out, r.rest);                                                                \
+  }
+
+#define ___CPC_TAKE_WHILE(name, pred, validate)                                                    \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    size_t i = 0;                                                                                  \
+    while (i < input.len && (pred)(input.ptr[i]))                                                  \
+      i++;                                                                                         \
+    validate;                                                                                      \
+    /* return the success from [0..i] and the rest from [i..len-i] */                              \
+    return cpc_res_ok(cpc_val_slice(cpc_slice_sub(input, 0, i)),                                   \
+                      cpc_slice_sub(input, i, input.len - i));                                     \
+  }
+
+// Consume input as long as the predicate returns true, and return the consumed
+// input. This parser requires the predicate to succeed on at least one char of
+// input: it will fail if the predicate never returns true or if there is no
+// input left.
+#define CPC_TAKE_WHILE_1(name, pred)                                                               \
+  ___CPC_TAKE_WHILE(name, pred, if (i < 1) return cpc_res_err(input, "too few", err))
+
+// Consume input as long as the predicate returns true, and return the consumed
+// input. This parser does not fail. If the predicate returns false at first
+// char, it returns an empty string as the slice. Does not fail.
+#define CPC_TAKE_WHILE(name, pred) ___CPC_TAKE_WHILE(name, pred, (void)0)
+
+#define ___CPC_MANY(name, parser, min_count, err_too_few)                                          \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    CpcValue out   = cpc_val_list(A);                                                              \
+    CpcSlice cur   = input;                                                                        \
+    size_t   count = 0;                                                                            \
+    size_t   min   = (size_t)(min_count);                                                          \
+    /* this loop will always terminate, see below conditions */                                    \
+    for (;;) {                                                                                     \
+      CpcResult r = (parser)(cur, A, err);                                                         \
+      if (!r.ok) {                                                                                 \
+        break;                                                                                     \
+      }                                                                                            \
+      if (cpc_no_progress_made(r.rest, cur))                                                       \
+        return cpc_res_internal_err(input, CPC_ERR_NO_PROGRESS);                                   \
+      if (!cpc_val_list_push(A, &out, r.out))                                                      \
+        return cpc_res_internal_err(input, CPC_ERR_ARENA_FULL);                                    \
+      cur = r.rest;                                                                                \
+      count++;                                                                                     \
+    }                                                                                              \
+    return count < min ? cpc_res_err(input, (err_too_few), err) : cpc_res_ok(out, cur);            \
+  }
+
+// Parses zero or more occurrences of the given parser.
+// Unlike the Haskell version this will always terminate, even when paired with
+// takewhile. Does not fail.
+#define CPC_MANY(name, parser) ___CPC_MANY(name, parser, 0, "too few")
+
+// Parses one or more occurrences of the given parser.
+#define CPC_MANY_1(name, parser) ___CPC_MANY(name, parser, 1, "too few")
+
+// Parses zero or more occurrences of parser `item`, until parser `end`
+// succeeds. Returns a list of values returned by p. Does not fail.
+#define CPC_MANY_TILL(name, item, end)                                                             \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    CpcValue out = cpc_val_list(A);                                                                \
+    CpcSlice cur = input;                                                                          \
+    /* this loop will always terminate, see below conditions */                                    \
+    for (;;) {                                                                                     \
+      CpcResult rend = (end)(cur, A, err);                                                         \
+      if (rend.ok) return cpc_res_ok(out, rend.rest);                                              \
+                                                                                                   \
+      CpcResult ritem = (item)(cur, A, err);                                                       \
+      if (!ritem.ok) return ritem;                                                                 \
+                                                                                                   \
+      if (cpc_no_progress_made(ritem.rest, cur))                                                   \
+        return cpc_res_internal_err(input, CPC_ERR_NO_PROGRESS);                                   \
+      if (!cpc_val_list_push(A, &out, ritem.out))                                                  \
+        return cpc_res_internal_err(input, CPC_ERR_ARENA_FULL);                                    \
+                                                                                                   \
+      cur = ritem.rest;                                                                            \
+    }                                                                                              \
+  }
+
+#define ___CPC_SEP_BY(name, item, sep, first_not_ok)                                               \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    CpcValue  out   = cpc_val_list(A);                                                             \
+    CpcSlice  cur   = input;                                                                       \
+    CpcResult first = (item)(cur, A, err);                                                         \
+    if (!first.ok) {                                                                               \
+      return first_not_ok;                                                                         \
+    }                                                                                              \
+                                                                                                   \
+    if (!cpc_val_list_push(A, &out, first.out))                                                    \
+      return cpc_res_internal_err(input, CPC_ERR_ARENA_FULL);                                      \
+                                                                                                   \
+    cur = first.rest;                                                                              \
+    /* this loop will always terminate, see below conditions */                                    \
+    for (;;) {                                                                                     \
+      CpcSlice  before_sep = cur;                                                                  \
+      CpcResult rsep       = (sep)(cur, A, err);                                                   \
+      if (!rsep.ok) {                                                                              \
+        break;                                                                                     \
+      }                                                                                            \
+      CpcResult next = (item)(rsep.rest, A, err);                                                  \
+      if (!next.ok) {                                                                              \
+        break;                                                                                     \
+      }                                                                                            \
+                                                                                                   \
+      if (!cpc_val_list_push(A, &out, next.out))                                                   \
+        return cpc_res_internal_err(input, CPC_ERR_ARENA_FULL);                                    \
+                                                                                                   \
+      cur = next.rest;                                                                             \
+      if (cpc_no_progress_made(cur, before_sep))                                                   \
+        return cpc_res_internal_err(input, CPC_ERR_NO_PROGRESS);                                   \
+    }                                                                                              \
+    return cpc_res_ok(out, cur);                                                                   \
+  }
+
+// Parses zero or more occurrences of `item`, separated by `sep`.
+// Returns a list of values returned by `item`. Does not fail.
+#define CPC_SEP_BY(name, item, sep) ___CPC_SEP_BY(name, item, sep, cpc_res_ok(out, input))
+
+// Parses one or more occurrences of `item`, separated by `sep`.
+// Returns a list of values returned by `item`.
+#define CPC_SEP_BY_1(name, item, sep)                                                              \
+  ___CPC_SEP_BY(name, item, sep, cpc_res_err(input, "too few", err))
+
+// Returns a value wrapped in the parser. Does not fail.
+#define CPC_PURE(name, value_expr)                                                                 \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    return cpc_res_ok((value_expr), input);                                                        \
+  }
+// Parses open, followed by inner and finally close. Only the value of inner is returned.
+#define CPC_BETWEEN(name, open, inner, close)                                                      \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    CpcResult ro = (open)(input, A, err);                                                          \
+    if (!ro.ok) return ro;                                                                         \
+    CpcResult ri = (inner)(ro.rest, A, err);                                                       \
+    if (!ri.ok) return ri;                                                                         \
+    CpcResult rc = (close)(ri.rest, A, err);                                                       \
+    if (!rc.ok) return rc;                                                                         \
+    return cpc_res_ok(ri.out, rc.rest);                                                            \
+  }
+
+// Run `parser` and tell what substring was matched, like attoparsec `match`
+#define CPC_MATCH(name, parser)                                                                    \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    /* mark is for restoring the arena state */                                                    \
+    size_t    mark = A->offset;                                                                    \
+    CpcResult r    = (parser)(input, A, err);                                                      \
+    A->offset      = mark;                                                                         \
+    return r.ok ? cpc_res_ok(                                                                      \
+                      cpc_val_slice(cpc_slice_sub(input, 0, (size_t)(r.rest.ptr - input.ptr))),    \
+                      r.rest)                                                                      \
+                : r;                                                                               \
+  }
+
+// Consume input as long as the predicate returns false, and return the consumed input.
+// This parser does not fail. If the predicate returns false at first
+// char, it returns an empty string as the slice.
+#define CPC_TAKE_TILL(name, pred)                                                                  \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    size_t i = 0;                                                                                  \
+    while (i < input.len && !(pred)(input.ptr[i]))                                                 \
+      i++;                                                                                         \
+    return cpc_res_ok(cpc_val_slice(cpc_slice_sub(input, 0, i)),                                   \
+                      cpc_slice_sub(input, i, input.len - i));                                     \
+  }
+
+#if defined(CPC_USE_STRING_H)
+// combination of CPC_TAKE_TILL + CPC_ONE_OF that is SIMD-friendly thanks
+// to memchr
+#  define CPC_TAKE_TILL_ONE_OF(name, stops)                                                        \
+    CPC_DEFINE_PARSER(name) {                                                                      \
+      size_t end = input.len;                                                                      \
+      for (const char *s = (stops); *s; ++s) {                                                     \
+        const char *p = memchr(input.ptr, *s, end);                                                \
+        if (p) end = (size_t)(p - input.ptr);                                                      \
+      }                                                                                            \
+      return cpc_res_ok(cpc_val_slice(cpc_slice_sub(input, 0, end)),                               \
+                        cpc_slice_sub(input, end, input.len - end));                               \
+    }
+
+// Parses a quoted string and returns a slice. Using the escape char to treat escaped content.
+#  define CPC_TAKE_QUOTED(name, quote, escape)                                                     \
+    CPC_DEFINE_PARSER(name) {                                                                      \
+      /* rejects anything that is too short (quoted would need at least 3 chars) or does not start \
+       * with the quote*/                                                                          \
+      if (input.len < 2 || input.ptr[0] != (quote))                                                \
+        return cpc_res_err(input, "missing quote", err);                                           \
+      /* start after the opening quote */                                                          \
+      size_t span = 1;                                                                             \
+      while (span < input.len) {                                                                   \
+        /* Jump to the next quote candidate instead of scanning char by char */                    \
+        const char *p = memchr(input.ptr + span, (quote), input.len - span);                       \
+        if (!p) break;                                                                             \
+        size_t idx = (size_t)(p - input.ptr);                                                      \
+        if ((escape) == (quote)) {                                                                 \
+          if ((idx + 1) < input.len && input.ptr[idx + 1] == (quote)) {                            \
+            /* A doubled quote is escaped content inside the quoted span */                        \
+            span = idx + 2;                                                                        \
+            continue;                                                                              \
+          }                                                                                        \
+        } else {                                                                                   \
+          size_t escapes = 0;                                                                      \
+          /* Count consecutive escape chars immediately before this quote candidate. */            \
+          while (idx > escapes && input.ptr[idx - 1 - escapes] == (escape))                        \
+            escapes++;                                                                             \
+                                                                                                   \
+          /* A quote preceded by an odd number of escape chars is escaped content. */              \
+          /* An even number like `//"` would mean that the backlash itself is escaped plus */      \
+          /* `"` would be a lone quote. */                                                         \
+          if ((escapes & 1u) != 0) {                                                               \
+            span = idx + 1;                                                                        \
+            continue;                                                                              \
+          }                                                                                        \
+        }                                                                                          \
+        /* A lone quote closes the span, including the opening quote at index 0 */                 \
+        span = idx + 1;                                                                            \
+        return cpc_res_ok(cpc_val_slice(cpc_slice_sub(input, 0, span)),                            \
+                          cpc_slice_sub(input, span, input.len - span));                           \
+      }                                                                                            \
+      /* err if no closing quote is found */                                                       \
+      return cpc_res_err(input, "missing quote", err);                                             \
+    }
+#endif
+
+#define ___CPC_EOF(name)                                                                           \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    return input.len == 0 ? cpc_res_ok(cpc_val_nothing(), input)                                   \
+                          : cpc_res_err(input, "expected eof", err);                               \
+  }
+
+// parser that only matches if all the input has been consumed
+#define CPC_EOF(name) ___CPC_EOF(name)
+    static inline ___CPC_EOF(CPC_EOF_)
+
+#define ___CPC_END_OF_LINE(name)                                                                   \
+  CPC_DEFINE_PARSER(name) {                                                                        \
+    if (input.len == 0) return cpc_res_err(input, "expected newline", err);                        \
+    const char *p = input.ptr;                                                                     \
+    if (p[0] == '\r') {                                                                            \
+      if (input.len >= 2 && p[1] == '\n')                                                          \
+        return cpc_res_ok(cpc_val_slice(cpc_slice_sub(input, 0, 2)),                               \
+                          cpc_slice_sub(input, 2, input.len - 2));                                 \
+      return cpc_res_ok(cpc_val_slice(cpc_slice_sub(input, 0, 1)),                                 \
+                        cpc_slice_sub(input, 1, input.len - 1));                                   \
+    }                                                                                              \
+    if (p[0] == '\n')                                                                              \
+      return cpc_res_ok(cpc_val_slice(cpc_slice_sub(input, 0, 1)),                                 \
+                        cpc_slice_sub(input, 1, input.len - 1));                                   \
+    return cpc_res_err(input, "expected newline", err);                                            \
+  }
+
+// Parses a CRLF (see crlf) or LF (see newline) end-of-line
+#define CPC_END_OF_LINE(name) ___CPC_END_OF_LINE(name)
+        static inline ___CPC_END_OF_LINE(CPC_END_OF_LINE_)
+
+#endif /* CPARSEC_H_INCLUDED */

--- a/src/csv.h
+++ b/src/csv.h
@@ -1,0 +1,52 @@
+#ifndef PG_CSV_PARSER_H
+#define PG_CSV_PARSER_H
+
+#define CPC_USE_STRING_H
+#define CPC_USE_UNNAMED
+#include "cparsec.h"
+
+// Strip the outer quotes and collapse doubled quotes inside one quoted field
+static CpcResult unescape_quoted(__attribute__((unused)) CpcArena *A, const CpcValue *v,
+                                 CpcSlice rest) {
+  // TODO should not happen
+  if (!v || v->kind != CPC_SLICE) return cpc_res_err(rest, "csv: expected slice", NULL);
+
+  CpcSlice s = v->as.slice;
+  // Leave non-quoted slices unchanged, only unescape fully quoted
+  if (s.len < 2 || s.ptr[0] != '"' || s.ptr[s.len - 1] != '"')
+    return cpc_res_ok(cpc_val_slice(s), rest);
+
+  char  *out = (char *)s.ptr + 1;
+  size_t dst = 0;
+  size_t src = 1;
+  size_t end = s.len - 1;
+  while (src < end) {
+    char c = s.ptr[src];
+    // Rewrite the quoted field in place, collapsing doubled quotes to one char
+    if (c == '"' && (src + 1) < end && s.ptr[src + 1] == '"') {
+      out[dst++] = '"';
+      src += 2;
+    } else {
+      out[dst++] = c;
+      src++;
+    }
+  }
+
+  return cpc_res_ok(cpc_val_slice((CpcSlice){.ptr = out, .len = dst}), rest);
+}
+
+
+extern CpcResult csvRow(CpcSlice input, CpcArena *A, const char *err);
+
+static inline CPC_TAKE_QUOTED(quoted, '"', '"')
+static inline CPC_MAP(quotedField, quoted, unescape_quoted)
+static inline CPC_TAKE_TILL_ONE_OF(unquotedField, ",\r\n")
+static inline CPC_STRING(comma, ",")
+static inline CPC_ALT(field_, quotedField, unquotedField)
+static inline CPC_LABEL(field, field_, "field")
+static inline CPC_SEP_BY_1(record, field, comma)
+static inline CPC_ALT(lineEnd_, CPC_END_OF_LINE_, CPC_EOF_)
+static inline CPC_LABEL(lineEnd, lineEnd_, "end of line")
+CPC_LEFT(csvRow, record, lineEnd)
+
+#endif

--- a/src/csv.h
+++ b/src/csv.h
@@ -35,9 +35,9 @@ static CpcResult unescape_quoted(__attribute__((unused)) CpcArena *A, const CpcV
   return cpc_res_ok(cpc_val_slice((CpcSlice){.ptr = out, .len = dst}), rest);
 }
 
-
 extern CpcResult csvRow(CpcSlice input, CpcArena *A, const char *err);
 
+// clang-format off
 static inline CPC_TAKE_QUOTED(quoted, '"', '"')
 static inline CPC_MAP(quotedField, quoted, unescape_quoted)
 static inline CPC_TAKE_TILL_ONE_OF(unquotedField, ",\r\n")
@@ -48,5 +48,6 @@ static inline CPC_SEP_BY_1(record, field, comma)
 static inline CPC_ALT(lineEnd_, CPC_END_OF_LINE_, CPC_EOF_)
 static inline CPC_LABEL(lineEnd, lineEnd_, "end of line")
 CPC_LEFT(csvRow, record, lineEnd)
+// clang-format on
 
 #endif

--- a/src/pg_csv.c
+++ b/src/pg_csv.c
@@ -4,8 +4,38 @@
 #include "pg_prelude.h"
 
 #include "aggs.h"
+#include "csv.h"
 
+PGDLLEXPORT const Pg_magic_struct *Pg_magic_func(void);
 PG_MODULE_MAGIC;
+
+static int count_visible_columns(TupleDesc tupdesc) {
+  int visible = 0;
+
+  for (int i = 0; i < tupdesc->natts; i++) {
+    if (!TupleDescAttr(tupdesc, i)->attisdropped) visible++;
+  }
+
+  return visible;
+}
+
+// We need a cstring to pass to functions like InputFunctionCall, as unfortunately it doesn't allow
+// passing a length. To avoid copying into a new buffer and appending it a `\0`, we take advantage
+// of some facts:
+// - The slice always point into a mutable input buffer
+// - The byte immediately after the slice is still within that same buffer. either a csv
+//   delimiter/newline or the trailing '\0' from text_to_cstring().
+static char *csv_slice_to_cstr(CpcSlice field) {
+  char *cstr      = (char *)field.ptr;
+  cstr[field.len] = '\0';
+  return cstr;
+}
+
+static bool attname_matches_cpc_slice(const char *attname, CpcSlice field) {
+  // This saves us calling strlen on the attname to compare it to the slice
+  return field.len < NAMEDATALEN && attname[field.len] == '\0' &&
+         pg_strncasecmp(attname, field.ptr, field.len) == 0;
+}
 
 // aggregate final function
 PG_FUNCTION_INFO_V1(csv_agg_finalfn);
@@ -127,4 +157,193 @@ Datum csv_agg_transfn(PG_FUNCTION_ARGS) {
   }
 
   PG_RETURN_POINTER(state);
+}
+
+PG_FUNCTION_INFO_V1(csv_populate_recordset);
+Datum csv_populate_recordset(PG_FUNCTION_ARGS) {
+  ReturnSetInfo *rsinfo = (ReturnSetInfo *)fcinfo->resultinfo;
+
+  if (rsinfo == NULL || !(rsinfo->allowedModes & SFRM_Materialize))
+    ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED), errmsg("materialize mode required")));
+
+  Oid base_type = get_fn_expr_argtype(fcinfo->flinfo, 0);
+  if (!OidIsValid(base_type))
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+                    errmsg("could not determine row type from first argument")));
+
+  if (PG_ARGISNULL(1))
+    ereport(ERROR, (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED), errmsg("from_csv must not be NULL")));
+
+  bool has_header = false;
+  if (PG_NARGS() >= 3) {
+    if (PG_ARGISNULL(2))
+      ereport(ERROR,
+              (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED), errmsg("has_header must not be NULL")));
+
+    has_header = PG_GETARG_BOOL(2);
+  }
+
+  TupleDesc srcdesc = lookup_rowtype_tupdesc(base_type, -1);
+  TupleDesc outdesc = BlessTupleDesc(CreateTupleDescCopy(srcdesc));
+  int       natts   = srcdesc->natts;
+  int       vnatts  = count_visible_columns(srcdesc);
+
+  if (vnatts == 0)
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("row type has no columns")));
+
+  FmgrInfo *infuncs  = palloc0(mul_size(natts, sizeof(FmgrInfo)));
+  Oid      *ioparams = palloc0(mul_size(natts, sizeof(Oid)));
+  int32    *typmods  = palloc0(mul_size(natts, sizeof(int32)));
+
+  for (int i = 0; i < natts; i++) {
+    Form_pg_attribute att = TupleDescAttr(srcdesc, i);
+    Oid               inoid;
+
+    if (att->attisdropped) continue;
+
+    getTypeInputInfo(att->atttypid, &inoid, &ioparams[i]);
+    fmgr_info(inoid, &infuncs[i]);
+    typmods[i] = att->atttypmod;
+  }
+
+  int *visible_attnos = palloc(mul_size(vnatts, sizeof(int)));
+  int  visible_idx    = 0;
+
+  for (int i = 0; i < natts; i++) {
+    if (!TupleDescAttr(srcdesc, i)->attisdropped) visible_attnos[visible_idx++] = i;
+  }
+
+  MemoryContext per_query_ctx = rsinfo->econtext->ecxt_per_query_memory;
+  MemoryContext oldctx        = MemoryContextSwitchTo(per_query_ctx);
+
+  rsinfo->returnMode = SFRM_Materialize;
+  rsinfo->setDesc    = outdesc;
+  rsinfo->setResult  = tuplestore_begin_heap(true, false, work_mem);
+
+  // Parse the input text row by row, then materialize each row into the tuplestore.
+  CpcSlice remaining = cpc_slice_from_cstr(text_to_cstring(PG_GETARG_TEXT_PP(1)));
+
+  // MaxHeapAttributeNumber is the maximum number of columns a table can have
+  CpcValue      arena_items[MaxHeapAttributeNumber];
+  CpcArena      arena       = {0};
+  int          *header_map  = NULL;
+  int           header_cols = 0;
+  Datum        *values      = palloc(mul_size(natts, sizeof(Datum)));
+  bool         *nulls       = palloc(mul_size(natts, sizeof(bool)));
+  MemoryContext row_ctx =
+      AllocSetContextCreate(per_query_ctx, "csv_populate_recordset row", ALLOCSET_DEFAULT_SIZES);
+  int64 row_number = 0;
+
+  cpc_arena_init(&arena, arena_items, MaxHeapAttributeNumber, NULL);
+
+  while (remaining.len > 0) {
+    // Reuse the arena for each csv row
+    cpc_arena_reset(&arena);
+
+    CpcResult parsed = CPC_PARSE(csvRow, remaining, &arena);
+
+    if (!parsed.ok) {
+      if (parsed.err.kind == CPC_ERR_ARENA_FULL)
+        ereport(ERROR,
+                (errcode(ERRCODE_PROGRAM_LIMIT_EXCEEDED),
+                 errmsg("CSV row has more than %d columns, which is the maximum in postgres.",
+                        MaxHeapAttributeNumber)));
+
+      ereport(ERROR, (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+                      errmsg("invalid CSV at row %lld: %s", (long long)(row_number + 1),
+                             parsed.err.msg ? parsed.err.msg : "parse error")));
+    }
+
+    row_number++;
+    remaining = parsed.rest;
+
+    if (!cpc_is_list(&parsed.out))
+      ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("unexpected parser output")));
+
+    size_t field_count = parsed.out.as.list.len;
+
+    // The first parsed row can map a column name to attribute number
+    if (has_header && header_map == NULL) {
+      bool *seen;
+
+      header_cols = (int)field_count;
+      header_map  = MemoryContextAlloc(per_query_ctx, mul_size(header_cols, sizeof(int)));
+      seen        = palloc0(mul_size(natts, sizeof(bool)));
+
+      for (int col = 0; col < header_cols; col++) {
+        const CpcValue *field = cpc_val_list_at(&arena, &parsed.out, col);
+        int             match = -1;
+
+        if (field == NULL || !cpc_is_slice(field))
+          ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("missing header column data")));
+
+        if (field->as.slice.len == 0)
+          ereport(ERROR, (errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+                          errmsg("header column %d is empty", col + 1)));
+
+        for (int i = 0; i < natts; i++) {
+          Form_pg_attribute att = TupleDescAttr(srcdesc, i);
+
+          if (att->attisdropped) continue;
+
+          if (attname_matches_cpc_slice(NameStr(att->attname), field->as.slice)) {
+            match = i;
+            break;
+          }
+        }
+
+        if (match < 0)
+          ereport(ERROR, (errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+                          errmsg("unknown column \"%.*s\" in header", (int)field->as.slice.len,
+                                 field->as.slice.ptr)));
+        if (seen[match])
+          ereport(ERROR, (errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+                          errmsg("duplicate column \"%.*s\" in header", (int)field->as.slice.len,
+                                 field->as.slice.ptr)));
+
+        seen[match]     = true;
+        header_map[col] = match;
+      }
+
+      continue;
+    }
+
+    if (field_count != (size_t)(has_header ? header_cols : vnatts))
+      ereport(ERROR, (errcode(ERRCODE_INVALID_TEXT_REPRESENTATION),
+                      errmsg("row %lld has %zu columns, expected %d", (long long)row_number,
+                             field_count, has_header ? header_cols : vnatts)));
+
+    // Convert the parsed field slices into typed Datums for one output tuple
+    MemoryContextReset(row_ctx);
+    MemoryContextSwitchTo(row_ctx);
+
+    for (int i = 0; i < natts; i++) {
+      values[i] = (Datum)0;
+      nulls[i]  = true;
+    }
+
+    for (int col = 0; col < (int)field_count; col++) {
+      const CpcValue *field     = cpc_val_list_at(&arena, &parsed.out, col);
+      int             att_index = has_header ? header_map[col] : visible_attnos[col];
+
+      if (field == NULL || !cpc_is_slice(field))
+        ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR), errmsg("missing row column data")));
+
+      if (field->as.slice.len == 0) continue;
+
+      values[att_index] = InputFunctionCall(&infuncs[att_index], csv_slice_to_cstr(field->as.slice),
+                                            ioparams[att_index], typmods[att_index]);
+      nulls[att_index]  = false;
+    }
+
+    // The tuple values must survive long enough to be copied into the tuplestore
+    MemoryContextSwitchTo(per_query_ctx);
+    tuplestore_putvalues(rsinfo->setResult, outdesc, values, nulls);
+  }
+
+  MemoryContextDelete(row_ctx);
+  MemoryContextSwitchTo(oldctx);
+  ReleaseTupleDesc(srcdesc);
+
+  return (Datum)0;
 }

--- a/src/pg_prelude.h
+++ b/src/pg_prelude.h
@@ -19,6 +19,7 @@
 #include <commands/extension.h>
 #include <executor/spi.h>
 #include <fmgr.h>
+#include <funcapi.h>
 #include <miscadmin.h>
 #include <nodes/makefuncs.h>
 #include <nodes/pg_list.h>
@@ -44,6 +45,7 @@
 #include <utils/memutils.h>
 #include <utils/regproc.h>
 #include <utils/snapmgr.h>
+#include <utils/tuplestore.h>
 #include <utils/typcache.h>
 #include <utils/varlena.h>
 

--- a/test/expected/populate.out
+++ b/test/expected/populate.out
@@ -1,0 +1,12 @@
+select * from csv_populate_recordset(null::projects, E'id,name,client_id\n1,IOS,4', true);
+ id | name | client_id 
+----+------+-----------
+  1 | IOS  |         4
+(1 row)
+
+select * from csv_populate_recordset(null::projects, E'1,IOS,4');
+ id | name | client_id 
+----+------+-----------
+  1 | IOS  |         4
+(1 row)
+

--- a/test/sql/populate.sql
+++ b/test/sql/populate.sql
@@ -1,0 +1,3 @@
+select * from csv_populate_recordset(null::projects, E'id,name,client_id\n1,IOS,4', true);
+
+select * from csv_populate_recordset(null::projects, E'1,IOS,4');


### PR DESCRIPTION
Adds a `csv_populate_recordset(anyelement, text, has_header bool default false)` that works much like `json_populate_recordset`:

```sql
select * from csv_populate_recordset(null::projects, E'id,name,client_id\n1,IOS,4', true);
 id | name | client_id
----+------+-----------
  1 | IOS  |         4
(1 row)

select * from csv_populate_recordset(null::projects, E'1,IOS,4');
 id | name | client_id
----+------+-----------
  1 | IOS  |         4
(1 row)

```

Implementation details
----------------------

This uses https://github.com/steve-chavez/CParseC/blob/master/cparsec.h and https://github.com/steve-chavez/CParseC/blob/master/bench/c/csv_simd.c (SIMD enabled CSV parsing). Importing these has been separated in a different commit for better diffing.

csv_populate_recordset uses `CPC_PARSE(csvRow..` and avoids pallocing in the hot path for good performance.

TODO
---------

- [ ] more tests